### PR TITLE
Move to use global layout and navigation structure

### DIFF
--- a/ECC-prototype/Gemfile
+++ b/ECC-prototype/Gemfile
@@ -42,6 +42,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  # for navigation and layouts
+  gem 'rails_layout'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/ECC-prototype/Gemfile.lock
+++ b/ECC-prototype/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       nokogiri (~> 1.6.0)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_layout (1.0.31)
     railties (5.0.0.1)
       actionpack (= 5.0.0.1)
       activesupport (= 5.0.0.1)
@@ -162,6 +163,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails_layout
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/ECC-prototype/app/assets/javascripts/application.js
+++ b/ECC-prototype/app/assets/javascripts/application.js
@@ -2,12 +2,12 @@
 // listed below.
 //
 // Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
 //
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// compiled file. JavaScript code in this file should be added after the last require_* statement.
+// compiled file.
 //
-// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
 //= require jquery

--- a/ECC-prototype/app/assets/stylesheets/application.css.scss
+++ b/ECC-prototype/app/assets/stylesheets/application.css.scss
@@ -3,12 +3,12 @@
  * listed below.
  *
  * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
+ * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
  *
  * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
+ * compiled file so the styles you add here take precedence over styles defined in any styles
+ * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
+ * file per style scope.
  *
  *= require_tree .
  *= require_self

--- a/ECC-prototype/app/assets/stylesheets/simple.css
+++ b/ECC-prototype/app/assets/stylesheets/simple.css
@@ -1,0 +1,50 @@
+/*
+ * Simple CSS stylesheet for a navigation bar and flash messages.
+ */
+main {
+  background-color: #eee;
+  padding-bottom: 80px;
+  width: 100%;
+  }
+header {
+  border: 1px solid #d4d4d4;
+  background-image: linear-gradient(to bottom, white, #f2f2f2);
+  background-color: #f9f9f9;
+  -webkit-box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+  -moz-box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+ul.nav li {
+  display: inline;
+}
+ul.nav li a {
+  padding: 10px 15px 10px;
+  color: #777777;
+  text-decoration: none;
+  text-shadow: 0 1px 0 white;
+}
+.flash_notice, .flash_alert {
+  padding: 8px 35px 8px 14px;
+  margin-bottom: 20px;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+  border: 1px solid #fbeed5;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+}
+.flash_notice {
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+  color: #468847;
+}
+.flash_alert {
+  background-color: #f2dede;
+  border-color: #eed3d7;
+  color: #b94a48;
+}
+

--- a/ECC-prototype/app/views/layouts/_messages.html.erb
+++ b/ECC-prototype/app/views/layouts/_messages.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |name, msg| %>
+  <% if msg.is_a?(String) %>
+    <%= content_tag :div, msg, :class => "flash_#{name}" %>
+  <% end %>
+<% end %>

--- a/ECC-prototype/app/views/layouts/_navigation.html.erb
+++ b/ECC-prototype/app/views/layouts/_navigation.html.erb
@@ -1,0 +1,4 @@
+<ul class="nav">
+  <!--#<li><%= link_to 'Home', root_path %></li>-->
+  <%= render 'layouts/navigation_links' %>
+</ul>

--- a/ECC-prototype/app/views/layouts/_navigation_links.html.erb
+++ b/ECC-prototype/app/views/layouts/_navigation_links.html.erb
@@ -1,0 +1,8 @@
+<%# add navigation links to this file %>
+<nav>
+      <a href="main">Home</a>
+      <a href="search">Advanced Search</a>
+      <a href="collections">Collections</a>
+      <a href="resources">Resources</a>
+      <a href="ethicslinks">Ethics &#64; IIT</a>
+  </nav>

--- a/ECC-prototype/app/views/layouts/application.html.erb
+++ b/ECC-prototype/app/views/layouts/application.html.erb
@@ -1,14 +1,23 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ECCPrototype</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= content_for?(:title) ? yield(:title) : "Ecc Prototype" %></title>
+    <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Ecc Prototype" %>">
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
-
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
-
   <body>
-    <%= yield %>
+    <header>
+      <figure>
+        <%= image_tag("cseplogo.png", :alt => "CSEP logo") %>
+      </figure>
+      <%= render 'layouts/navigation' %>
+    </header>
+    <main role="main">
+      <%= render 'layouts/messages' %>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/ECC-prototype/app/views/static/collections.html.erb
+++ b/ECC-prototype/app/views/static/collections.html.erb
@@ -1,39 +1,15 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Ethics Code Collection</title>
-    <%= favicon_link_tag 'iiticon.png' %>
-    <meta charset="utf-8">
-    <!--Mobile specific-->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no"/>
-</head>
-
-<body>
-    <figure>
-        <%= image_tag("cseplogo.png", :alt => "CSEP logo") %>
-    </figure>
-
-    <h1>Collections</h1>
-    <nav>
-        <a href="main">Home</a>
-        <a href="search">Advanced Search</a>
-        <a href="collections">Collections</a>
-        <a href="resources">Resources</a>
-        <a href="ethicslinks">Ethics &#64; IIT</a>
-    </nav>
-    <h2>Agriculture</h2>
-        <p>Ethics codes from agricultural organizations can go here. Consult with org team to see proper categories.</p>
-    <h2>Business</h2>
-        <p>Ethics codes from business organizations can go here. Consult with org team to see proper categories.</p>
-    <h2>Health Care</h2>
-        <p>Ethics codes from health care organizations can go here. Consult with org team to see proper categories.</p>
-    <h2>Legal</h2>
-        <p>Ethics codes from legal organizations can go here. Consult with org team to see proper categories.</p>
-    <h2>Media</h2>
-        <p>Ethics codes from media organizations can go here. Consult with org team to see proper categories.</p>
-    <h2>Real Estate</h2>
-        <p>Ethics codes from real estate organizations can go here. Consult with org team to see proper categories.</p>
-    <h2>Science</h2>
-        <p>Ethics codes from science organizations can go here. Consult with org team to see proper categories.</p>
-</body>
-</html>
+<h1>Collections</h1>
+<h2>Agriculture</h2>
+    <p>Ethics codes from agricultural organizations can go here. Consult with org team to see proper categories.</p>
+<h2>Business</h2>
+    <p>Ethics codes from business organizations can go here. Consult with org team to see proper categories.</p>
+<h2>Health Care</h2>
+    <p>Ethics codes from health care organizations can go here. Consult with org team to see proper categories.</p>
+<h2>Legal</h2>
+    <p>Ethics codes from legal organizations can go here. Consult with org team to see proper categories.</p>
+<h2>Media</h2>
+    <p>Ethics codes from media organizations can go here. Consult with org team to see proper categories.</p>
+<h2>Real Estate</h2>
+    <p>Ethics codes from real estate organizations can go here. Consult with org team to see proper categories.</p>
+<h2>Science</h2>
+    <p>Ethics codes from science organizations can go here. Consult with org team to see proper categories.</p>

--- a/ECC-prototype/app/views/static/ethicslinks.html.erb
+++ b/ECC-prototype/app/views/static/ethicslinks.html.erb
@@ -1,31 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Ethics Code Collection</title>
-    <%= favicon_link_tag 'iiticon.png' %>
-    <meta charset="utf-8">
-    <!--Mobile specific-->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no"/>
-</head>
-
-<body>
-    <figure>
-        <%= image_tag("cseplogo.png", :alt => "CSEP logo") %>
-    </figure>
-
-    <h1>Ethics &#64; IIT</h1>
-    <nav>
-        <a href="main">Home</a>
-        <a href="search">Advanced Search</a>
-        <a href="collections">Collections</a>
-        <a href="resources">Resources</a>
-        <a href="ethicslinks">Ethics &#64; IIT</a>
-    </nav>
-    <h2>Collections Policy</h2>
-        <p>Pull from existing site.</p>
-    <h2>Ethics Blog</h2>
-        <p>External link to blog.</p>
-    <h2>CSEP Home Page</h2>
-        <p>External link to CSEP Organization.</p>
-</body>
-</html>
+<h1>Ethics &#64; IIT</h1>
+<h2>Collections Policy</h2>
+    <p>Pull from existing site.</p>
+<h2>Ethics Blog</h2>
+    <p>External link to blog.</p>
+<h2>CSEP Home Page</h2>
+    <p>External link to CSEP Organization.</p>

--- a/ECC-prototype/app/views/static/main.html.erb
+++ b/ECC-prototype/app/views/static/main.html.erb
@@ -1,29 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Ethics Code Collection</title>
-    <%= favicon_link_tag 'iiticon.png' %>
-    <meta charset="utf-8">
-    <!--Mobile specific-->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no"/>
-</head>
-
-<body>
-    <figure>
-        <%= image_tag("cseplogo.png", :alt => "CSEP logo") %>
-    </figure>
-
-    <h1>Ethics Code Collection</h1>
-    <nav>
-        <a href="main">Home</a>
-        <a href="search">Advanced Search</a>
-        <a href="collections">Collections</a>
-        <a href="resources">Resources</a>
-        <a href="ethicslinks">Ethics &#64; IIT</a>
-    </nav>
-    <p>Short blurb here about what Ethics Code Collection encompasses. How to use this tool, etc. Make sure site resembles a large search tool.</p>
-    <h2>About Us</h2>
-    <h2>Mission Statement</h2>
-    <h2>Social Media</h2>
-</body>
-</html>
+<h1>Ethics Code Collection</h1>
+<p>Short blurb here about what Ethics Code Collection encompasses. How to use this tool, etc. Make sure site resembles a large search tool.</p>
+<h2>About Us</h2>
+<h2>Mission Statement</h2>
+<h2>Social Media</h2>

--- a/ECC-prototype/app/views/static/resources.html.erb
+++ b/ECC-prototype/app/views/static/resources.html.erb
@@ -1,33 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Ethics Code Collection</title>
-    <%= favicon_link_tag 'iiticon.png' %>
-    <meta charset="utf-8">
-    <!--Mobile specific-->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no"/>
-</head>
-
-<body>
-    <figure>
-        <%= image_tag("cseplogo.png", :alt => "CSEP logo") %>
-    </figure>
-
-    <h1>Resources</h1>
-    <nav>
-        <a href="main">Home</a>
-        <a href="search">Advanced Search</a>
-        <a href="collections">Collections</a>
-        <a href="resources">Resources</a>
-        <a href="ethicslinks">Ethics &#64; IIT</a>
-    </nav>
-    <h2>Authoring A Code</h2>
-        <p>Guidelines as to how to write a code to add to the collection. Pull from existing site.</p>
-    <h2>Bibliography</h2>
-        <p>Sources citing here.</p>
-    <h2>Collection Policy</h2>
-        <p>Policies of the ECC. Pull from existing site.</p>
-    <h2>Print Guide</h2>
-        <p>Guide, to be pulled from existing site.</p>
-</body>
-</html>
+<h1>Resources</h1>
+<h2>Authoring A Code</h2>
+    <p>Guidelines as to how to write a code to add to the collection. Pull from existing site.</p>
+<h2>Bibliography</h2>
+    <p>Sources citing here.</p>
+<h2>Collection Policy</h2>
+    <p>Policies of the ECC. Pull from existing site.</p>
+<h2>Print Guide</h2>
+    <p>Guide, to be pulled from existing site.</p>

--- a/ECC-prototype/app/views/static/search.html.erb
+++ b/ECC-prototype/app/views/static/search.html.erb
@@ -1,26 +1,2 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Ethics Code Collection</title>
-    <%= favicon_link_tag 'iiticon.png' %>
-    <meta charset="utf-8">
-    <!--Mobile specific-->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no"/>
-</head>
-
-<body>
-    <figure>
-        <%= image_tag("cseplogo.png", :alt => "CSEP logo") %>
-    </figure>
-
-    <h1>Advanced Search</h1>
-    <nav>
-        <a href="main">Home</a>
-        <a href="search">Advanced Search</a>
-        <a href="collections">Collections</a>
-        <a href="resources">Resources</a>
-        <a href="ethicslinks">Ethics &#64; IIT</a>
-    </nav>
-    <p>Search has filters like subject area, organization, resource type, profession, etc.</p>
-</body>
-</html>
+<h1>Advanced Search</h1>
+<p>Search has filters like subject area, organization, resource type, profession, etc.</p>


### PR DESCRIPTION
Rather than having repetition for headers and navigation in each html file we how use the html.erb files in `app/views/layouts` to render the main layout including navigation, headers, footers, and css styles.

This makes all the static html files simple and non-repetitive.
## Before (main.html)

<img width="1233" alt="screen shot 2016-09-20 at 3 22 17 pm" src="https://cloud.githubusercontent.com/assets/11952698/18687554/3bdd037c-7f46-11e6-93a2-4655acee539b.png">

<img width="928" alt="screen shot 2016-09-20 at 3 22 56 pm" src="https://cloud.githubusercontent.com/assets/11952698/18687571/54225284-7f46-11e6-9fe6-ab3793b95f6c.png">
## After (main.html)

<img width="1187" alt="screen shot 2016-09-20 at 3 22 04 pm" src="https://cloud.githubusercontent.com/assets/11952698/18687591/713cbca6-7f46-11e6-8457-7cdf9fa20bc7.png">

<img width="1024" alt="screen shot 2016-09-20 at 3 23 13 pm" src="https://cloud.githubusercontent.com/assets/11952698/18687600/7e02bbac-7f46-11e6-9480-bb49e3d2398e.png">
